### PR TITLE
Restore txt as preferred extension for text/plain

### DIFF
--- a/src/MimeTypesFactory.php
+++ b/src/MimeTypesFactory.php
@@ -21,6 +21,7 @@ final class MimeTypesFactory
         $builder->add('application/gzip', 'gz');
         $builder->add('application/vnd.ms-outlook', 'msg');
         $builder->add('application/dat', 'dat');
+        $builder->add('text/plain', 'txt');
 
         return new MimeTypes($builder->getMapping());
     }

--- a/tests/MimeTypesFactoryTest.php
+++ b/tests/MimeTypesFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DEMV\File\Test;
+
+use DEMV\File\MimeTypesFactory;
+use PHPUnit\Framework\TestCase;
+
+final class MimeTypesFactoryTest extends TestCase
+{
+    public function testCustomMimeMappings(): void
+    {
+        $mimeTypes = MimeTypesFactory::create();
+
+        $this->assertSame('application/gzip', $mimeTypes->getMimeType('gzip'));
+        $this->assertSame('application/gzip', $mimeTypes->getMimeType('gz'));
+        $this->assertSame('application/vnd.ms-outlook', $mimeTypes->getMimeType('msg'));
+        $this->assertSame('application/dat', $mimeTypes->getMimeType('dat'));
+    }
+
+    public function testTextPlainPrefersTxtExtension(): void
+    {
+        $mimeTypes = MimeTypesFactory::create();
+
+        $this->assertSame('txt', $mimeTypes->getExtension('text/plain'));
+        $this->assertSame('text/plain', $mimeTypes->getMimeType('env'));
+        $this->assertSame('text/plain', $mimeTypes->getMimeType('txt'));
+    }
+}


### PR DESCRIPTION
elephox/mimey deliberately maps text/plain to the env extension first (elephox-dev/mimey@d72acba), so getExtension('text/plain') returned 'env' since the switch from the ralouphie/mimey fork.
Consumers using the mime-to-extension direction to name files (AttachmentFilenameFixer in bipro-transfer) would have produced '*.env' instead of '*.txt' for text/plain attachments without a usable filename extension.
Prepending txt restores the previous behavior; env remains a known extension.